### PR TITLE
Gross CHP capacity additions were still missing in mappingvars

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '45368976'
+ValidationKey: '45388192'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "limes: The liMES R package",
-  "version": "2.36.1",
+  "version": "2.36.2",
   "description": "<p>Contains the LIMES-specific routines for data and model\n    output manipulation.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: limes
 Title: The liMES R package
-Version: 2.36.1
+Version: 2.36.2
 Date: 2022-08-12
 Authors@R: 
     person("Sebastian", "Osorio", , "sebastian.osorio@pik-potsdam.de", role = c("aut", "cre"))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The liMES R package
 
-R package **limes**, version **2.36.1**
+R package **limes**, version **2.36.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/limes)](https://cran.r-project.org/package=limes)  [![R build status](https://github.com/pik-piam/limes/workflows/check/badge.svg)](https://github.com/pik-piam/limes/actions) [![codecov](https://codecov.io/gh/pik-piam/limes/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/limes) [![r-universe](https://pik-piam.r-universe.dev/badges/limes)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Sebastian Osorio <sebastian.osori
 
 To cite package **limes** in publications use:
 
-Osorio S (2022). _limes: The liMES R package_. R package version 2.36.1.
+Osorio S (2022). _limes: The liMES R package_. R package version 2.36.2.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,6 +48,6 @@ A BibTeX entry for LaTeX users is
   title = {limes: The liMES R package},
   author = {Sebastian Osorio},
   year = {2022},
-  note = {R package version 2.36.1},
+  note = {R package version 2.36.2},
 }
 ```

--- a/inst/extdata/MappingVars.csv
+++ b/inst/extdata/MappingVars.csv
@@ -1365,3 +1365,19 @@ Capacity Additions|Electricity|Storage Reservoir|Intra-day;Capacity Additions|El
 Capacity Additions|Electricity|Storage Reservoir|Pump Hydro;Capacity Additions|Electricity|Storage Reservoir|Pump Hydro;GW/yr;GW/yr;1
 Capacity Additions|Electricity|Storage Reservoir|Stat Batteries;Capacity Additions|Electricity|Storage Reservoir|Stat Batteries;GW/yr;GW/yr;1
 Capacity Additions|Electricity|Storage Reservoir|Hydrogen electrolysis;Capacity Additions|Electricity|Storage Reservoir|Hydrogen electrolysis;GW/yr;GW/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP;Capacity Additions|Gross|Heat|District Heating|CHP;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Hydrogen;Capacity Additions|Gross|Heat|District Heating|CHP|Hydrogen;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Biomass;Capacity Additions|Gross|Heat|District Heating|CHP|Biomass;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Coal;Capacity Additions|Gross|Heat|District Heating|CHP|Coal;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Gas CC;Capacity Additions|Gross|Heat|District Heating|CHP|Gas CC;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Gas OC;Capacity Additions|Gross|Heat|District Heating|CHP|Gas OC;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Gas;Capacity Additions|Gross|Heat|District Heating|CHP|Gas;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Hard Coal;Capacity Additions|Gross|Heat|District Heating|CHP|Hard Coal;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Lignite;Capacity Additions|Gross|Heat|District Heating|CHP|Lignite;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Oil;Capacity Additions|Gross|Heat|District Heating|CHP|Oil;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Other;Capacity Additions|Gross|Heat|District Heating|CHP|Other;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Waste;Capacity Additions|Gross|Heat|District Heating|CHP|Waste;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Other Fossil;Capacity Additions|Gross|Heat|District Heating|CHP|Other Fossil;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Fossil;Capacity Additions|Gross|Heat|District Heating|CHP|Fossil;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Renewable;Capacity Additions|Gross|Heat|District Heating|CHP|Renewable;GWh/yr;GWh/yr;1
+Capacity Additions|Gross|Heat|District Heating|CHP|Non-renewable;Capacity Additions|Gross|Heat|District Heating|CHP|Non-renewable;GWh/yr;GWh/yr;1


### PR DESCRIPTION
I thought they were there but I was confused by the electrical capacities additions. This is just a change in the mappingvars file